### PR TITLE
Remove usage of lookbehind regex expression

### DIFF
--- a/src/VJsonParse.res
+++ b/src/VJsonParse.res
@@ -26,7 +26,7 @@ let parseVJsonWithVariable = parseVariableString => {
     \"<|>"(str("true") |> map(_ => true), str("false") |> map(_ => false)) |> lexeme
 
   let escapedQuoteRegex = %re(`/\\\\"/gm`)
-  let nonEsacapedQuoteRegex = %re(`/((?:^|[^\\\\])(?:\\\\{2})*)"/gm`)
+  let nonEscapedQuoteRegex = %re(`/((?:^|[^\\\\])(?:\\\\{2})*)"/gm`)
   let inQuotesRegex = %re(`/"(?:[^"\\\\]|\\\\.)*"/`)
   // Parse a string. Allows for escaped quotes.
   // NOTE: not to be confused with `parse`, which takes a raw string and parses
@@ -35,7 +35,7 @@ let parseVJsonWithVariable = parseVariableString => {
     regex(inQuotesRegex)
     |> map(match => {
       match
-      ->Js.String2.replaceByRe(nonEsacapedQuoteRegex, `$1`) // First group of the regex is characters before the quote that should be kept
+      ->Js.String2.replaceByRe(nonEscapedQuoteRegex, `$1`) // First group of the regex is characters before the quote that should be kept
       ->Js.String2.replaceByRe(escapedQuoteRegex, `"`)
     })
     |> lexeme

--- a/src/VJsonParse.res
+++ b/src/VJsonParse.res
@@ -26,6 +26,7 @@ let parseVJsonWithVariable = parseVariableString => {
     \"<|>"(str("true") |> map(_ => true), str("false") |> map(_ => false)) |> lexeme
 
   let escapedQuoteRegex = %re(`/\\\\"/gm`)
+  let nonEsacapedQuoteRegex = %re(`/(?<!\\\\)(?:\\\\{2})*"/gm`)
   let inQuotesRegex = %re(`/"(?:[^"\\\\]|\\\\.)*"/`)
   // Parse a string. Allows for escaped quotes.
   // NOTE: not to be confused with `parse`, which takes a raw string and parses
@@ -34,15 +35,8 @@ let parseVJsonWithVariable = parseVariableString => {
     regex(inQuotesRegex)
     |> map(match => {
       match
-      // Get rid of all non-escaped quotes by temporarily replacing escaped quotes with a unique string
-      // then replacing that string with a quote after remaining non-escaped quotes have been removed.
-      //
-      // Detecting non-escaped quotes directly with a regex would require a lookbehind, which is not
-      // supported on recent versions of Safari. https://caniuse.com/js-regexp-lookbehind
-      // let nonEsacapedQuoteRegex = %re(`/(?<!\\\\)(?:\\\\{2})*"/gm`)
-      ->Js.String2.replaceByRe(escapedQuoteRegex, `__ESCAPED__QUOTE__`)
-      ->Js.String2.replaceByRe(%re(`/"/gm`), ``)
-      ->Js.String2.replaceByRe(%re(`/__ESCAPED__QUOTE__/gm`), `"`)
+      ->Js.String2.replaceByRe(nonEsacapedQuoteRegex, ``)
+      ->Js.String2.replaceByRe(escapedQuoteRegex, `"`)
     })
     |> lexeme
 

--- a/src/VJsonParse.res
+++ b/src/VJsonParse.res
@@ -26,7 +26,6 @@ let parseVJsonWithVariable = parseVariableString => {
     \"<|>"(str("true") |> map(_ => true), str("false") |> map(_ => false)) |> lexeme
 
   let escapedQuoteRegex = %re(`/\\\\"/gm`)
-  let nonEsacapedQuoteRegex = %re(`/(?<!\\\\)(?:\\\\{2})*"/gm`)
   let inQuotesRegex = %re(`/"(?:[^"\\\\]|\\\\.)*"/`)
   // Parse a string. Allows for escaped quotes.
   // NOTE: not to be confused with `parse`, which takes a raw string and parses
@@ -35,8 +34,15 @@ let parseVJsonWithVariable = parseVariableString => {
     regex(inQuotesRegex)
     |> map(match => {
       match
-      ->Js.String2.replaceByRe(nonEsacapedQuoteRegex, ``)
-      ->Js.String2.replaceByRe(escapedQuoteRegex, `"`)
+      // Get rid of all non-escaped quotes by temporarily replacing escaped quotes with a unique string
+      // then replacing that string with a quote after remaining non-escaped quotes have been removed.
+      //
+      // Detecting non-escaped quotes directly with a regex would require a lookbehind, which is not
+      // supported on recent versions of Safari. https://caniuse.com/js-regexp-lookbehind
+      // let nonEsacapedQuoteRegex = %re(`/(?<!\\\\)(?:\\\\{2})*"/gm`)
+      ->Js.String2.replaceByRe(escapedQuoteRegex, `__ESCAPED__QUOTE__`)
+      ->Js.String2.replaceByRe(%re(`/"/gm`), ``)
+      ->Js.String2.replaceByRe(%re(`/__ESCAPED__QUOTE__/gm`), `"`)
     })
     |> lexeme
 

--- a/src/VJsonParse.res
+++ b/src/VJsonParse.res
@@ -26,7 +26,7 @@ let parseVJsonWithVariable = parseVariableString => {
     \"<|>"(str("true") |> map(_ => true), str("false") |> map(_ => false)) |> lexeme
 
   let escapedQuoteRegex = %re(`/\\\\"/gm`)
-  let nonEsacapedQuoteRegex = %re(`/(?<!\\\\)(?:\\\\{2})*"/gm`)
+  let nonEsacapedQuoteRegex = %re(`/((?:^|[^\\\\])(?:\\\\{2})*)"/gm`)
   let inQuotesRegex = %re(`/"(?:[^"\\\\]|\\\\.)*"/`)
   // Parse a string. Allows for escaped quotes.
   // NOTE: not to be confused with `parse`, which takes a raw string and parses
@@ -35,7 +35,7 @@ let parseVJsonWithVariable = parseVariableString => {
     regex(inQuotesRegex)
     |> map(match => {
       match
-      ->Js.String2.replaceByRe(nonEsacapedQuoteRegex, ``)
+      ->Js.String2.replaceByRe(nonEsacapedQuoteRegex, `$1`) // First group of the regex is characters before the quote that should be kept
       ->Js.String2.replaceByRe(escapedQuoteRegex, `"`)
     })
     |> lexeme


### PR DESCRIPTION
- The lookbehind regex is not supported on recent safari versions: https://caniuse.com/js-regexp-lookbehind, it only got support recently. 
- This causes the builder to crash for people that have a slightly older version of safari. Safari also requires mac os upgrades to update, so some users might not be able to update their macos or safari and would therefore never be able to access the builder.
- I couldn't figure out a regex that does not use the lookbehind, so this is the approach I went with, but let me know if you have other suggestions. 